### PR TITLE
base64 execute cmd

### DIFF
--- a/image/postgresql/pgtools
+++ b/image/postgresql/pgtools
@@ -25,6 +25,7 @@ backup=0
 backup_info=0
 restore=0
 backup_delete=0
+do_exec_base64_string=0
 
 # set env
 DATA=${DATA:-/var/lib/postgresql/data}
@@ -83,7 +84,7 @@ BACKUP_RESTORE_CONF="postgresql_backup_restore.conf"
 ###########
 
 # parse argument
-while getopts "acdDe:hHp:q:w:Q:norRs:S:bEvB" arg
+while getopts "acdDe:hHp:q:w:Q:norRs:S:bEvBf:" arg
 do
 	case $arg in
 		a)
@@ -110,30 +111,34 @@ do
 			env_value=${OPTARG#*=}
 			export "$env_name"="$env_value"
 			;;
+		f)
+			do_exec_base64_string="$OPTARG"
+			;;
 		h)
 			echo "pgtools is util for manage postgresql"
 			echo "every command in container run by it"
-			echo "  -a        init finish and connect success."
-			echo "  -c        flush postgresql config file"
-			echo "  -d        drop the auto_failover node"
-			echo "  -D        actual drop the auto_failover node, this node can't start again"
-			echo "  -e env    set environment befor running"
-			echo "  -h        help"
-			echo "  -H        flush hba file"
-			echo "  -p action pause/resume  pause or resume start postgresql"
-			echo "  -q query  run the query"
-			echo "  -w second timeout for query"
-			echo "  -Q        run the query on this database"
-			echo "  -n        if failed not return error"
-			echo "  -o        perform switchover"
-			echo "  -r        restart postgresql"
-			echo "  -R        stop auto_failover"
-			echo "  -E        restore cluster from s3 backup"
-			echo "  -v        get s3 backup information or backup size"
-			echo "  -b        backup cluster to s3"
-			echo "  -B        backup_delete by policy"
-			echo "  -s value  set auto_failover config: pg_autoctl config set.."
-			echo "  -S value  set auto_failover: pg_autoctl set.."
+			echo "  -a            init finish and connect success."
+			echo "  -c            flush postgresql config file"
+			echo "  -d            drop the auto_failover node"
+			echo "  -D            actual drop the auto_failover node, this node can't start again"
+			echo "  -e env        set environment befor running"
+			echo "  -f base64cmd  execute base64-encoded string"
+			echo "  -h            help"
+			echo "  -H            flush hba file"
+			echo "  -p action     pause/resume  pause or resume start postgresql"
+			echo "  -q query      run the query"
+			echo "  -w second     timeout for query"
+			echo "  -Q            run the query on this database"
+			echo "  -n            if failed not return error"
+			echo "  -o            perform switchover"
+			echo "  -r            restart postgresql"
+			echo "  -R            stop auto_failover"
+			echo "  -E            restore cluster from s3 backup"
+			echo "  -v            get s3 backup information or backup size"
+			echo "  -b            backup cluster to s3"
+			echo "  -B            backup_delete by policy"
+			echo "  -s value      set auto_failover config: pg_autoctl config set.."
+			echo "  -S value      set auto_failover: pg_autoctl set.."
 			exit 0
 			;;
 		H)
@@ -676,6 +681,13 @@ fi
 
 if [ "${backup_delete}" = 1 ]; then
 	delete_backup
+fi
+
+if [ "${do_exec_base64_string}" != 0 ]; then
+	cmd=$(echo $do_exec_base64_string | base64 -d)
+	# using eval $cmd replace $cmd, $cmd execute failed
+	eval $cmd
+	exit $?
 fi
 
 exit 0


### PR DESCRIPTION
func:
1. use base64 to encode command to prevent execution errors caused by '|' and '>'
2. change waiting_postgresql_recovery_completed timeout to 1 days
3. name contains "-" characters causing rebuild failure problem fixed